### PR TITLE
fix(i18n): translate display info surfaces

### DIFF
--- a/src/components/displays/display-state-card.tsx
+++ b/src/components/displays/display-state-card.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from '../../i18n/index';
 
 type DisplayStateCardProps = {
   state: DisplayState;
+  title?: string;
 };
 
 type ItemProps = {
@@ -25,7 +26,7 @@ export const DisplayStateCard: Component<DisplayStateCardProps> = (props) => {
     <div class="card bg-base-200 shadow-lg hover:shadow-xl transition-shadow duration-200">
       <div class="card-body p-4">
         <div class="card-title text-base mb-3 flex items-center justify-between gap-2">
-          <span class="flex-1 min-w-0">{t('displays.title')}</span>
+          <span class="flex-1 min-w-0">{props.title ?? t('displays.title')}</span>
           <div class="badge badge-primary badge-outline whitespace-nowrap">{t('common.realtime')}</div>
         </div>
 

--- a/src/components/info/info-index.tsx
+++ b/src/components/info/info-index.tsx
@@ -12,7 +12,7 @@ const logger = debug('app:components:info:info-index');
 export const InfoIndex: Component = () => {
   const [displayStates, setDisplayStates] = createSignal<DisplayState[]>([]);
   const [displayConfigs, setDisplayConfigs] = createSignal<any[]>([]);
-  const { t } = useLanguage();
+  const { t, locale } = useLanguage();
 
   createEffect(() => {
     // 获取DDC显示器状态
@@ -49,6 +49,38 @@ export const InfoIndex: Component = () => {
     },
   };
 
+  const getDisplayName = (config: any, index: number) => {
+    const rawName = typeof config?.name === 'string' ? config.name.trim() : '';
+
+    if (rawName) {
+      if (locale() === 'en-US') {
+        if (config?.is_primary && rawName.includes('主显示器')) {
+          return t('displays.primaryDisplayName');
+        }
+
+        const match = rawName.match(/显示器\s*(\d+)/);
+        if (match) {
+          return `${t('displays.displayLabel')} ${match[1]}`;
+        }
+      }
+
+      if (locale() === 'zh-CN') {
+        const displayMatch = rawName.match(/Display\s*(\d+)/i);
+        if (displayMatch) {
+          return `${t('displays.displayLabel')} ${displayMatch[1]}`;
+        }
+      }
+
+      return rawName;
+    }
+
+    if (config?.is_primary) {
+      return t('displays.primaryDisplayName');
+    }
+
+    return `${t('displays.displayLabel')} ${index + 1}`;
+  };
+
   return (
     <div class="space-y-8">
       <WebSocketListener handlers={webSocketHandlers} />
@@ -72,32 +104,33 @@ export const InfoIndex: Component = () => {
             {(config, index) => {
               // 尝试找到对应的DDC状态
               const ddcState = displayStates().find((state, stateIndex) => stateIndex === index());
+              const displayName = getDisplayName(config, index());
 
               return (
                 <div class="relative">
                   {ddcState ? (
-                    <DisplayStateCard state={ddcState} />
+                    <DisplayStateCard state={ddcState} title={displayName} />
                   ) : (
                     <div class="card bg-base-100 shadow-xl">
                       <div class="card-body">
-                        <h2 class="card-title text-base-content">{config.name}</h2>
+                        <h2 class="card-title text-base-content">{displayName}</h2>
                         <div class="space-y-2">
                           <div class="flex justify-between items-center py-1">
-                            <dt class="text-sm font-medium text-base-content/70">分辨率</dt>
+                            <dt class="text-sm font-medium text-base-content/70">{t('displays.resolution')}</dt>
                             <dd class="text-sm font-mono text-base-content">{config.width}x{config.height}</dd>
                           </div>
                           <div class="flex justify-between items-center py-1">
-                            <dt class="text-sm font-medium text-base-content/70">缩放比例</dt>
+                            <dt class="text-sm font-medium text-base-content/70">{t('displays.scaleFactor')}</dt>
                             <dd class="text-sm font-mono text-base-content">{config.scale_factor}</dd>
                           </div>
                           <div class="flex justify-between items-center py-1">
-                            <dt class="text-sm font-medium text-base-content/70">主显示器</dt>
-                            <dd class="text-sm font-mono text-base-content">{config.is_primary ? '是' : '否'}</dd>
+                            <dt class="text-sm font-medium text-base-content/70">{t('displays.isPrimary')}</dt>
+                            <dd class="text-sm font-mono text-base-content">{config.is_primary ? t('common.yes') : t('common.no')}</dd>
                           </div>
                           <div class="flex justify-between items-center py-1">
-                            <dt class="text-sm font-medium text-base-content/70">状态</dt>
+                            <dt class="text-sm font-medium text-base-content/70">{t('info.status')}</dt>
                             <dd class="text-sm font-mono text-base-content">
-                              <span class="badge badge-warning">不支持DDC控制</span>
+                              <span class="badge badge-warning">{t('displays.ddcUnsupported')}</span>
                             </dd>
                           </div>
                         </div>

--- a/src/components/led-preview/led-preview.tsx
+++ b/src/components/led-preview/led-preview.tsx
@@ -17,7 +17,7 @@ export interface LedPreviewProps {
 }
 
 export function LedPreview(props: LedPreviewProps) {
-  const { t } = useLanguage();
+  const { t, locale } = useLanguage();
   const [sortedColors, setSortedColors] = createSignal<Uint8ClampedArray>(new Uint8ClampedArray(0));
   const [connected, setConnected] = createSignal(false);
   const [lastUpdateTime, setLastUpdateTime] = createSignal<Date | null>(null);
@@ -348,8 +348,8 @@ export function LedPreview(props: LedPreviewProps) {
 
   // 格式化时间（只显示时分秒）
   const formatTimeOnly = (date: Date | null) => {
-    if (!date) return '无数据';
-    return date.toLocaleString('zh-CN', {
+    if (!date) return t('common.noData');
+    return date.toLocaleString(locale(), {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
@@ -371,7 +371,7 @@ export function LedPreview(props: LedPreviewProps) {
         when={displayInfo().colors.length > 0}
         fallback={
           <div class="flex items-center justify-center h-16 text-base-content/60 text-xs bg-base-100 border border-base-300 rounded">
-            <div class="opacity-70">等待状态数据...</div>
+            <div class="opacity-70">{t('ledStatus.waitingForData')}</div>
           </div>
         }
       >

--- a/src/components/led-strip-configuration/single-display-config.tsx
+++ b/src/components/led-strip-configuration/single-display-config.tsx
@@ -302,6 +302,7 @@ const LedBorderAddButton: Component<{
   strips: LedStripConfig[];
   onCreateStrip: (border: 'Top' | 'Bottom' | 'Left' | 'Right') => Promise<void>;
 }> = (props) => {
+  const { t } = useLanguage();
   // 获取该边框的LED灯带数量
   const stripCount = createMemo(() => {
     // 安全检查：确保 strips 存在且是数组
@@ -388,16 +389,17 @@ const LedBorderAddButton: Component<{
 
   const getButtonText = () => {
     if (props.border === 'Left' || props.border === 'Right') {
-      return '+';  // 纵向只显示加号
+      return '+'; // 纵向只显示加号
     }
-    return stripCount() > 0 ? '+ 添加更多' : '+ 添加LED灯带';
+    const label = stripCount() > 0 ? t('singleDisplayConfig.addMoreStrip') : t('singleDisplayConfig.addStrip');
+    return `+ ${label}`;
   };
 
   return (
     <div
       style={getAddButtonStyle()}
       onClick={async () => await props.onCreateStrip(props.border)}
-      title={`点击添加${props.border}边LED灯带`}
+      title={t('singleDisplayConfig.addStripTooltip')}
       class="hover:bg-blue-200 hover:border-blue-400"
     >
       {getButtonText()}
@@ -961,10 +963,16 @@ export function SingleDisplayConfig() {
 
     console.log(`📊 总计: ${cumulativeLedOffset} 个LED`);
 
-    alert(`调试信息已输出到控制台。当前有 ${currentStrips.length} 个灯带配置，总计 ${cumulativeLedOffset} 个LED。`);
+    const debugMessage = [
+      t('singleDisplayConfig.debugInfoAlertIntro'),
+      `${t('singleDisplayConfig.debugInfoAlertStripCountPrefix')} ${currentStrips.length}`,
+      `${t('singleDisplayConfig.debugInfoAlertLedCountPrefix')} ${cumulativeLedOffset}`
+    ].join('\n');
+    alert(debugMessage);
     } catch (error) {
       console.error('❌ 调试函数执行失败:', error);
-      alert('❌ 调试函数执行失败: ' + (error instanceof Error ? error.message : String(error)));
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      alert(`${t('singleDisplayConfig.debugInfoAlertError')} ${errorMessage}`);
     }
   };
 
@@ -1045,9 +1053,9 @@ export function SingleDisplayConfig() {
           <button
             class="btn btn-outline btn-info"
             on:click={debugCurrentConfig}
-            title="在控制台显示调试信息"
+            title={t('singleDisplayConfig.debugInfoTooltip')}
           >
-            调试信息
+            {t('singleDisplayConfig.debugInfo')}
           </button>
           <button
             class="btn btn-outline btn-error"
@@ -1092,8 +1100,8 @@ export function SingleDisplayConfig() {
                   {/* 显示器信息 */}
                   <div class="absolute inset-0 flex items-center justify-center">
                     <div class="text-center">
-                      <div class="font-semibold">Display {displayId()}</div>
-                      <div class="text-sm text-base-content/60">LED Configuration</div>
+                      <div class="font-semibold">{t('singleDisplayConfig.displayLabel')} {displayId()}</div>
+                      <div class="text-sm text-base-content/60">{t('singleDisplayConfig.ledConfiguration')}</div>
                     </div>
                   </div>
                 </div>
@@ -1142,8 +1150,8 @@ export function SingleDisplayConfig() {
               <div class="card bg-base-100 shadow-lg">
                 <div class="card-body text-center text-base-content/60">
                   <p>{t('singleDisplayConfig.selectOrCreateStrip')}</p>
-                  <p class="text-xs mt-2">当前选中: {selectedStrip() ? selectedStrip()!.id : '无'}</p>
-                  <p class="text-xs">总灯带数: {ledStrips().length}</p>
+                  <p class="text-xs mt-2">{t('singleDisplayConfig.currentSelection')} {selectedStrip() ? selectedStrip()!.id : t('singleDisplayConfig.none')}</p>
+                  <p class="text-xs">{t('singleDisplayConfig.totalStripCount')} {ledStrips().length}</p>
                 </div>
               </div>
             }

--- a/src/components/led-strip-test/led-strip-test.tsx
+++ b/src/components/led-strip-test/led-strip-test.tsx
@@ -636,14 +636,14 @@ export const LedStripTest = () => {
           </div>
 
           {/* LED配置数据测试按钮 */}
-          <div class="divider">LED配置数据测试</div>
+          <div class="divider">{t('ledTest.configDataTest')}</div>
           <div class="flex gap-4">
             <button
               class="btn btn-secondary"
               onClick={testLedConfigData}
               disabled={!selectedBoard()}
             >
-              🔧 测试LED配置数据发送
+              {t('ledTest.sendConfigData')}
             </button>
           </div>
 

--- a/src/i18n/locales/en-US.ts
+++ b/src/i18n/locales/en-US.ts
@@ -14,6 +14,8 @@ export const enUS: TranslationDict = {
   common: {
     version: 'Version',
     primary: 'Primary',
+    yes: 'Yes',
+    no: 'No',
     save: 'Save',
     cancel: 'Cancel',
     reset: 'Reset',
@@ -100,6 +102,9 @@ export const enUS: TranslationDict = {
     // Display info panel specific
     id: 'ID',
     scale: 'Scale',
+    ddcUnsupported: 'DDC control not supported',
+    primaryDisplayName: 'Primary Display',
+    displayLabel: 'Display',
   },
   
   ledConfig: {
@@ -174,8 +179,21 @@ export const enUS: TranslationDict = {
     // Save status
     configSaved: 'Configuration saved',
     saveFailed: 'Save failed',
-    saving: 'Saving...',
-    saveConfig: 'Save Configuration',
+   saving: 'Saving...',
+   saveConfig: 'Save Configuration',
+    debugInfo: 'Debug Info',
+    debugInfoTooltip: 'Print detailed LED strip configuration to console',
+    debugInfoAlertIntro: 'Debug information has been printed to the console.',
+    debugInfoAlertStripCountPrefix: 'Configured strips:',
+    debugInfoAlertLedCountPrefix: 'Total LEDs:',
+    debugInfoAlertError: 'Failed to run debug helper:',
+    currentSelection: 'Current selection:',
+    none: 'None',
+    totalStripCount: 'Total strips:',
+    addMoreStrip: 'Add More',
+    addStrip: 'Add LED Strip',
+    addStripTooltip: 'Click to add an LED strip',
+    displayLabel: 'Display',
   },
   
   colorCalibration: {
@@ -266,6 +284,8 @@ export const enUS: TranslationDict = {
     connected: 'Connected',
     connecting: 'Connecting',
     disconnected: 'Disconnected',
+    configDataTest: 'LED Configuration Data Test',
+    sendConfigData: '🔧 Send LED configuration data',
   },
   
   errors: {
@@ -373,6 +393,25 @@ export const enUS: TranslationDict = {
       StripConfig: 'Configuration',
       TestEffect: 'Test Mode',
       ColorCalibration: 'Color Calibration',
+    },
+  },
+
+  websocket: {
+    connected: 'Connected',
+    disconnected: 'Disconnected',
+    messages: 'Messages',
+    lastMessage: 'Last',
+    connect: 'Connect',
+    disconnect: 'Disconnect',
+    events: {
+      ledColorsChanged: 'LED colors updated',
+      ledSortedColorsChanged: 'LED colors (sorted) updated',
+      ledStripColorsChanged: 'LED strip colors updated',
+      configChanged: 'Configuration updated',
+      ambientLightStateChanged: 'Ambient light status updated',
+      boardsChanged: 'Device list updated',
+      displaysChanged: 'Display status updated',
+      navigate: 'Navigation event',
     },
   },
 };

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -14,6 +14,8 @@ export const zhCN: TranslationDict = {
   common: {
     version: '版本',
     primary: '主要',
+    yes: '是',
+    no: '否',
     save: '保存',
     cancel: '取消',
     reset: '重置',
@@ -100,6 +102,9 @@ export const zhCN: TranslationDict = {
     // Display info panel specific
     id: 'ID',
     scale: '缩放',
+    ddcUnsupported: '不支持DDC控制',
+    primaryDisplayName: '主显示器',
+    displayLabel: '显示器',
   },
   
   ledConfig: {
@@ -176,6 +181,19 @@ export const zhCN: TranslationDict = {
     saveFailed: '保存失败',
     saving: '保存中...',
     saveConfig: '保存配置',
+    debugInfo: '调试信息',
+    debugInfoTooltip: '在控制台输出详细的灯带配置信息',
+    debugInfoAlertIntro: '调试信息已输出到控制台。',
+    debugInfoAlertStripCountPrefix: '当前灯带数量：',
+    debugInfoAlertLedCountPrefix: 'LED总数：',
+    debugInfoAlertError: '调试函数执行失败：',
+    currentSelection: '当前选中：',
+    none: '无',
+    totalStripCount: '总灯带数：',
+    addMoreStrip: '添加更多',
+    addStrip: '添加LED灯带',
+    addStripTooltip: '点击添加LED灯带',
+    displayLabel: '显示器',
   },
   
   colorCalibration: {
@@ -266,6 +284,8 @@ export const zhCN: TranslationDict = {
     connected: '已连接',
     connecting: '连接中',
     disconnected: '已断开',
+    configDataTest: 'LED配置数据测试',
+    sendConfigData: '🔧 测试LED配置数据发送',
   },
   
   errors: {
@@ -373,6 +393,25 @@ export const zhCN: TranslationDict = {
       StripConfig: '配置模式',
       TestEffect: '测试模式',
       ColorCalibration: '颜色校准',
+    },
+  },
+
+  websocket: {
+    connected: '已连接',
+    disconnected: '未连接',
+    messages: '消息',
+    lastMessage: '最新',
+    connect: '连接',
+    disconnect: '断开',
+    events: {
+      ledColorsChanged: 'LED颜色更新',
+      ledSortedColorsChanged: 'LED颜色（按物理顺序）更新',
+      ledStripColorsChanged: 'LED灯带颜色更新',
+      configChanged: '配置更新',
+      ambientLightStateChanged: '氛围灯状态更新',
+      boardsChanged: '设备列表更新',
+      displaysChanged: '显示器状态更新',
+      navigate: '导航事件',
     },
   },
 };

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -16,6 +16,8 @@ export interface TranslationDict {
   common: {
     version: string;
     primary: string;
+    yes: string;
+    no: string;
     save: string;
     cancel: string;
     reset: string;
@@ -104,6 +106,9 @@ export interface TranslationDict {
     // Display info panel specific
     id: string;
     scale: string;
+    ddcUnsupported: string;
+    primaryDisplayName: string;
+    displayLabel: string;
   };
   
   // LED Strip Configuration
@@ -180,6 +185,19 @@ export interface TranslationDict {
     saveFailed: string;
     saving: string;
     saveConfig: string;
+    debugInfo: string;
+    debugInfoTooltip: string;
+    debugInfoAlertIntro: string;
+    debugInfoAlertStripCountPrefix: string;
+    debugInfoAlertLedCountPrefix: string;
+    debugInfoAlertError: string;
+    currentSelection: string;
+    none: string;
+    totalStripCount: string;
+    addMoreStrip: string;
+    addStrip: string;
+    addStripTooltip: string;
+    displayLabel: string;
   };
   
   // Color Calibration
@@ -272,6 +290,8 @@ export interface TranslationDict {
     connected: string;
     connecting: string;
     disconnected: string;
+    configDataTest: string;
+    sendConfigData: string;
   };
   
   // Error messages
@@ -382,6 +402,25 @@ export interface TranslationDict {
       StripConfig: string;
       TestEffect: string;
       ColorCalibration: string;
+    };
+  };
+
+  websocket: {
+    connected: string;
+    disconnected: string;
+    messages: string;
+    lastMessage: string;
+    connect: string;
+    disconnect: string;
+    events: {
+      ledColorsChanged: string;
+      ledSortedColorsChanged: string;
+      ledStripColorsChanged: string;
+      configChanged: string;
+      ambientLightStateChanged: string;
+      boardsChanged: string;
+      displaysChanged: string;
+      navigate: string;
     };
   };
 }


### PR DESCRIPTION
## Summary
- localize display information cards and websocket status strings
- add missing dictionary entries for LED configuration and test views
- update LED preview and settings UI to source text from the i18n layer

## Testing
- bun run lint
- vite build